### PR TITLE
fix: remove redundant bound checks in from_signed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ macro_rules! define_ux {
 				if x < 0 {
 					None
 				} else {
-					Self::new(x as $unsigned)
+					Some(Self(x as $unsigned))
 				}
 			}
 


### PR DESCRIPTION
Resolving the Issue 5: https://github.com/rotorship/oblux/issues/5

Cargo build is success and all tests are passing:
<img width="696" height="629" alt="image" src="https://github.com/user-attachments/assets/31e49265-1ca8-468c-84b1-bd8475e553c3" />
